### PR TITLE
Feature/support snapshot identifier

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ resource "aws_rds_cluster" "default" {
   master_password                     = var.password
   master_username                     = var.username
   skip_final_snapshot                 = var.skip_final_snapshot
+  snapshot_identifier                 = var.snapshot_identifier
   storage_encrypted                   = var.storage_encrypted
   tags                                = var.tags
   vpc_security_group_ids              = [aws_security_group.default.id]

--- a/main.tf
+++ b/main.tf
@@ -69,12 +69,12 @@ resource "aws_rds_cluster" "default" {
   final_snapshot_identifier           = var.final_snapshot_identifier
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   iam_roles                           = var.iam_roles
-  kms_key_id                          = var.kms_key_id #tfsec:ignore:AWS051
+  kms_key_id                          = var.kms_key_id
   master_password                     = var.password
   master_username                     = var.username
   skip_final_snapshot                 = var.skip_final_snapshot
   snapshot_identifier                 = var.snapshot_identifier
-  storage_encrypted                   = var.storage_encrypted
+  storage_encrypted                   = var.storage_encrypted #tfsec:ignore:AWS051
   tags                                = var.tags
   vpc_security_group_ids              = [aws_security_group.default.id]
 

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "aws_rds_cluster" "default" {
   final_snapshot_identifier           = var.final_snapshot_identifier
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   iam_roles                           = var.iam_roles
-  kms_key_id                          = var.kms_key_id  #tfsec:ignore:AWS051
+  kms_key_id                          = var.kms_key_id #tfsec:ignore:AWS051
   master_password                     = var.password
   master_username                     = var.username
   skip_final_snapshot                 = var.skip_final_snapshot

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "aws_rds_cluster" "default" {
   final_snapshot_identifier           = var.final_snapshot_identifier
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
   iam_roles                           = var.iam_roles
-  kms_key_id                          = var.kms_key_id
+  kms_key_id                          = var.kms_key_id  #tfsec:ignore:AWS051
   master_password                     = var.password
   master_username                     = var.username
   skip_final_snapshot                 = var.skip_final_snapshot

--- a/variables.tf
+++ b/variables.tf
@@ -192,7 +192,7 @@ variable "skip_final_snapshot" {
 variable "snapshot_identifier" {
   type        = string
   default     = null
-  description = "DB snapshot to create this database from"
+  description = "Database snapshot identifier to create the database from"
 }
 
 variable "stack" {

--- a/variables.tf
+++ b/variables.tf
@@ -191,7 +191,7 @@ variable "skip_final_snapshot" {
 
 variable "snapshot_identifier" {
   type        = string
-  default     = ""
+  default     = null
   description = "DB snapshot to create this database from"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,12 @@ variable "skip_final_snapshot" {
   description = "Determines whether a final snapshot is created before deleting the cluster"
 }
 
+variable "snapshot_identifier" {
+  type        = string
+  default     = ""
+  description = "DB snapshot to create this database from"
+}
+
 variable "stack" {
   type        = string
   description = "The stack name for the Aurora Cluster"


### PR DESCRIPTION
Add support to allow the use of a final snapshot to be used for importing data into a new instance. This is useful when destroying and recreating an instance during migrations of instances. 