### PR TITLE
add performance_insights_kms_key_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,6 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   monitoring_interval             = var.monitoring_interval
   monitoring_role_arn             = try(module.rds_enhanced_monitoring_role[0].arn, null)
   performance_insights_enabled    = var.performance_insights
-  performance_insights_kms_key_id = var.kms_key_id
+  performance_insights_kms_key_id = var.performance_insights_kms_key_id
   publicly_accessible             = var.publicly_accessible
 }

--- a/variables.tf
+++ b/variables.tf
@@ -165,6 +165,12 @@ variable "performance_insights" {
   description = "Specifies whether Performance Insights is enabled or not"
 }
 
+variable "performance_insights_kms_key_id" {
+  type        = string
+  default     = ""
+  description = "The KMS key ID used for the PI encryption"
+}
+
 variable "permissions_boundary" {
   type        = string
   default     = null


### PR DESCRIPTION
without this var if kms_key_kd is set, performance insights
can't be disabled, forcing you to use an instance type that
supports PI (>=large). This increases costs