### PR TITLE
Enable "copy_tags_to_snapshot" feature

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,4 +66,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.0.2
+        uses: triat/terraform-security-scan@v3.0.0

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 | database | The name of the first database to be created when the cluster is created | `string` | `null` | no |
 | database\_parameters | A list of instance DB parameters to apply | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `null` | no |
 | deletion\_protection | A boolean indicating if the DB instance should have deletion protection enable | `bool` | `true` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | `list(string)` | `[]` | no |
 | enable\_http\_endpoint | Enable Aurora Serverless HTTP endpoint (Data API) | `bool` | `false` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | `list(string)` | `null` | no |
 | engine | The engine type of the Aurora cluster | `string` | `"aurora"` | no |
 | engine\_mode | The engine mode of the Aurora cluster | `string` | `"serverless"` | no |
 | engine\_version | The engine version of the Aurora cluster | `string` | `"5.6.10a"` | no |
@@ -44,12 +44,14 @@
 | instance\_count | The number of RDS instances to attach. Only for serverless engine\_mode | `number` | `1` | no |
 | kms\_key\_id | The KMS key ID used for the storage encryption | `string` | `null` | no |
 | max\_capacity | The maximum capacity of the serverless cluster | `string` | `8` | no |
-| monitoring\_interval | The interval (seconds) for collecting enhanced monitoring metrics | `string` | `0` | no |
 | min\_capacity | The minimum capacity of the serverless cluster | `string` | `1` | no |
-| performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not | `bool` | `false` | no |
+| monitoring\_interval | The interval (seconds) for collecting enhanced monitoring metrics | `string` | `null` | no |
+| performance\_insights | Specifies whether Performance Insights is enabled or not | `bool` | `false` | no |
+| permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the role | `string` | `null` | no |
 | publicly\_accessible | Control if instances in cluster are publicly accessible | `string` | `false` | no |
 | security\_group\_ids | List of security group IDs allowed to connect to Aurora | `list(string)` | `[]` | no |
 | skip\_final\_snapshot | Determines whether a final snapshot is created before deleting the cluster | `bool` | `false` | no |
+| snapshot\_identifier | Database snapshot identifier to create the database from | `string` | `null` | no |
 | storage\_encrypted | Specifies whether the DB cluster is encrypted | `bool` | `true` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | apply\_immediately | Specifies whether any cluster modifications are applied immediately | `bool` | `true` | no |
 | auto\_pause | Whether to enable automatic pause | `bool` | `true` | no |
 | availability\_zones | List of availability zones to deploy Aurora in | `list(string)` | `[]` | no |
-| backup\_retention\_period | The days to retain backups for | `number` | `1` | no |
+| backup\_retention\_period | The days to retain backups for | `number` | `7` | no |
 | cidr\_blocks | List of CIDR blocks that should be allowed access to the Aurora cluster | `list(string)` | `null` | no |
 | cluster\_family | The family of the DB cluster parameter group | `string` | `"aurora5.6"` | no |
 | cluster\_parameters | A list of cluster DB parameters to apply | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "character_set_server",<br>    "value": "utf8"<br>  },<br>  {<br>    "name": "character_set_client",<br>    "value": "utf8"<br>  }<br>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ resource "aws_rds_cluster" "default" {
   apply_immediately                   = var.apply_immediately
   backup_retention_period             = var.backup_retention_period
   cluster_identifier                  = var.stack
+  copy_tags_to_snapshot               = true
   database_name                       = var.database
   db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.default.name
   db_subnet_group_name                = aws_db_subnet_group.default.name

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "availability_zones" {
 
 variable "backup_retention_period" {
   type        = number
-  default     = 1
+  default     = 7
   description = "The days to retain backups for"
 }
 


### PR DESCRIPTION
(Always) enable the feature to copy the tags of the cluster to snapshots.

As suggested by Security Hub: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#rds-16-remediation