### PR TITLE
fix to be able to disable performance insights while using encryption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,6 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   monitoring_interval             = var.monitoring_interval
   monitoring_role_arn             = try(module.rds_enhanced_monitoring_role[0].arn, null)
   performance_insights_enabled    = var.performance_insights
-  performance_insights_kms_key_id = var.kms_key_id
+  performance_insights_kms_key_id = var.performance_insights ? var.kms_key_id : null
   publicly_accessible             = var.publicly_accessible
 }


### PR DESCRIPTION
Currently you cant disable performance insight if you specify a kms key
this pr will set the performance_insights_kms_key_id to null if the var performance_insights is set to false