### PR TITLE
Add support for Serverless V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
+| aws | >= 4.12.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 4.12.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@
 | availability\_zones | List of availability zones to deploy Aurora in | `list(string)` | `[]` | no |
 | backup\_retention\_period | The days to retain backups for | `number` | `7` | no |
 | cidr\_blocks | List of CIDR blocks that should be allowed access to the Aurora cluster | `list(string)` | `null` | no |
-| cluster\_family | The family of the DB cluster parameter group | `string` | `"aurora5.6"` | no |
+| cluster\_family | The family of the DB cluster parameter group | `string` | `"aurora-mysql5.7"` | no |
 | cluster\_parameters | A list of cluster DB parameters to apply | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "character_set_server",<br>    "value": "utf8"<br>  },<br>  {<br>    "name": "character_set_client",<br>    "value": "utf8"<br>  }<br>]</pre> | no |
 | database | The name of the first database to be created when the cluster is created | `string` | `null` | no |
 | database\_parameters | A list of instance DB parameters to apply | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `null` | no |
 | deletion\_protection | A boolean indicating if the DB instance should have deletion protection enable | `bool` | `true` | no |
 | enable\_http\_endpoint | Enable Aurora Serverless HTTP endpoint (Data API) | `bool` | `false` | no |
 | enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | `list(string)` | `null` | no |
-| engine | The engine type of the Aurora cluster | `string` | `"aurora"` | no |
+| engine | The engine type of the Aurora cluster | `string` | `"aurora-mysql"` | no |
 | engine\_mode | The engine mode of the Aurora cluster | `string` | `"serverless"` | no |
-| engine\_version | The engine version of the Aurora cluster | `string` | `"5.6.10a"` | no |
+| engine\_version | The engine version of the Aurora cluster | `string` | `"5.7.mysql_aurora.2.08.3"` | no |
 | final\_snapshot\_identifier | Identifier of the final snapshot to create before deleting the cluster | `string` | `null` | no |
 | iam\_database\_authentication\_enabled | Specify if mapping AWS IAM accounts to database accounts is enabled. | `bool` | `null` | no |
 | iam\_roles | A list of IAM Role ARNs to associate with the cluster | `list(string)` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_rds_cluster" "default" {
   enabled_cloudwatch_logs_exports     = var.enabled_cloudwatch_logs_exports
   enable_http_endpoint                = var.enable_http_endpoint
   engine                              = var.engine
-  engine_mode                         = var.engine_mode
+  engine_mode                         = var.engine_mode == "serverlessv2" ? "provisioned" : var.engine_mode
   engine_version                      = var.engine_version
   final_snapshot_identifier           = var.final_snapshot_identifier
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
@@ -90,6 +90,15 @@ resource "aws_rds_cluster" "default" {
       seconds_until_auto_pause = 1800
     }
   }
+
+  dynamic "serverlessv2_scaling_configuration" {
+    for_each = var.engine_mode == "serverlessv2" ? { create : null } : {}
+    content {
+      max_capacity = var.max_capacity
+      min_capacity = var.min_capacity
+    }
+  }
+
 }
 
 resource "aws_db_parameter_group" "default" {
@@ -130,12 +139,11 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   engine                                = var.engine
   engine_version                        = var.engine_version
   identifier                            = "${var.stack}-${count.index}"
-  instance_class                        = var.instance_class
+  instance_class                        = var.engine_mode == "serverlessv2" ? "db.serverless" : var.instance_class
   monitoring_interval                   = var.monitoring_interval
   monitoring_role_arn                   = try(module.rds_enhanced_monitoring_role[0].arn, null)
   performance_insights_enabled          = var.performance_insights
   performance_insights_kms_key_id       = var.performance_insights ? var.kms_key_id : null
   performance_insights_retention_period = var.performance_insights ? var.performance_insights_retention_period : null
   publicly_accessible                   = var.publicly_accessible
-  tags                                  = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -146,4 +146,5 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   performance_insights_kms_key_id       = var.performance_insights ? var.kms_key_id : null
   performance_insights_retention_period = var.performance_insights ? var.performance_insights_retention_period : null
   publicly_accessible                   = var.publicly_accessible
+  tags                                  = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "cidr_blocks" {
 
 variable "cluster_family" {
   type        = string
-  default     = "aurora5.6"
+  default     = "aurora-mysql5.7"
   description = "The family of the DB cluster parameter group"
 }
 
@@ -84,7 +84,7 @@ variable "enable_http_endpoint" {
 
 variable "engine" {
   type        = string
-  default     = "aurora"
+  default     = "aurora-mysql"
   description = "The engine type of the Aurora cluster"
 }
 
@@ -92,11 +92,16 @@ variable "engine_mode" {
   type        = string
   default     = "serverless"
   description = "The engine mode of the Aurora cluster"
+
+  validation {
+    condition     = contains(["provisioned", "serverless", "parallelquery", "global", "multimaster", "serverlessv2"], var.engine_mode)
+    error_message = "Allowed values for engine_mode are \"provisioned\", \"serverless\", \"parallelquery\", \"global\", \"multimaster\" or \"serverlessv2\"."
+  }
 }
 
 variable "engine_version" {
   type        = string
-  default     = "5.6.10a"
+  default     = "5.7.mysql_aurora.2.08.3"
   description = "The engine version of the Aurora cluster"
 }
 
@@ -188,6 +193,7 @@ variable "preferred_maintenance_window" {
   default     = null
   description = "The weekly time range during which system maintenance can occur, in UTC e.g. wed:04:00-wed:04:30"
 }
+
 variable "publicly_accessible" {
   type        = string
   default     = false

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 4.12.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR creates support for Aurora Serverless V2, and removes the "Default Mysql 5.6" settings (and updates it to Mysql 5.7)

## Serverless V2
Made changes to support Serverless V2. For Serverless V2 the engine mode is actually `provisioned`, but since this makes the configuration even more complex with all the options available (creating an RDS with TF is one big parameterized resource) I've created a new, non-existing, engine mode `serverlessv2`.

When the engine mode is set to `serverlessv2`, this module sets the correct parameters.

Documentation:

- https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.create-cluster.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#rds-serverless-v2-cluster

## Remove MySQL 5.6
WIthin Serverless V1, there is a "Mysql V1" and "MySQL V2". V2, which is MySQL 5.6, is deprecated and new instances cannot be created anymore. Also changed the "default" settings to MySQL 5.7

Documentation:

- https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html

(And bumped the mcaf-role module, but that has no impact)