### PR TITLE
Add `apply_method` to parameter groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,9 @@ resource "aws_rds_cluster_parameter_group" "default" {
     for_each = var.cluster_parameters
 
     content {
-      name  = parameter.value.name
-      value = parameter.value.value
+      apply_method = parameter.value.apply_method
+      name         = parameter.value.name
+      value        = parameter.value.value
     }
   }
 }
@@ -112,8 +113,9 @@ resource "aws_db_parameter_group" "default" {
     for_each = var.database_parameters
 
     content {
-      name  = parameter.value.name
-      value = parameter.value.value
+      apply_method = parameter.value.apply_method
+      name         = parameter.value.name
+      value        = parameter.value.value
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,8 +36,9 @@ variable "cluster_family" {
 
 variable "cluster_parameters" {
   type = list(object({
-    name  = string
-    value = string
+    apply_method = optional(string, "immediate")
+    name         = string
+    value        = string
   }))
   default = [{
     name  = "character_set_server",
@@ -57,8 +58,9 @@ variable "database" {
 
 variable "database_parameters" {
   type = list(object({
-    name  = string
-    value = string
+    apply_method = optional(string, "immediate")
+    name         = string
+    value        = string
   }))
   default     = null
   description = "A list of instance DB parameters to apply"

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 4.12.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
The default apply method is `immediate` but not all settings can be set immediately and need a reboot. This keeps default behavior but allows people to set `pending-reboot` when needed.

Signed-off-by: Stephen Hoekstra <stephenhoekstra@gmail.com>
