### PR TITLE
Add timeout_action to scaling_configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ resource "aws_rds_cluster" "default" {
       max_capacity             = var.max_capacity
       min_capacity             = var.min_capacity
       seconds_until_auto_pause = 1800
+      timeout_action           = var.timeout_action
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -241,6 +241,12 @@ variable "tags" {
   description = "A mapping of tags to assign to the bucket"
 }
 
+variable "timeout_action" {
+  type        = string
+  default     = "RollbackCapacityChange"
+  description = "The action to take when the timeout is reached"
+}
+
 variable "username" {
   type        = string
   description = "Username for the master DB user"


### PR DESCRIPTION
Adds timeout_action as a variable to be able to change the action to take when the timeout is reached. This is specially useful for clusters that can't find a scaling point and therefore don't scale. This can then be solved by setting it to `ForceApplyCapacityChange`.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#scaling_configuration-argument-reference