### PR TITLE
Calculate skip_final_snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@
 | preferred\_maintenance\_window | The weekly time range during which system maintenance can occur, in UTC e.g. wed:04:00-wed:04:30 | `string` | `null` | no |
 | publicly\_accessible | Control if instances in cluster are publicly accessible | `string` | `false` | no |
 | security\_group\_ids | List of security group IDs allowed to connect to Aurora | `list(string)` | `[]` | no |
-| skip\_final\_snapshot | Determines whether a final snapshot is created before deleting the cluster | `bool` | `false` | no |
 | snapshot\_identifier | Database snapshot identifier to create the database from | `string` | `null` | no |
 | storage\_encrypted | Specifies whether the DB cluster is encrypted | `bool` | `true` | no |
+| timeout\_action | The action to take when the timeout is reached | `string` | `"RollbackCapacityChange"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  skip_final_snapshot = var.final_snapshot_identifier == null
+}
+
 data "aws_subnet" "selected" {
   id = var.subnet_ids[0]
 }
@@ -76,7 +80,7 @@ resource "aws_rds_cluster" "default" {
   kms_key_id                          = var.kms_key_id
   master_password                     = var.password
   master_username                     = var.username
-  skip_final_snapshot                 = var.skip_final_snapshot
+  skip_final_snapshot                 = local.skip_final_snapshot
   snapshot_identifier                 = var.snapshot_identifier
   storage_encrypted                   = var.storage_encrypted #tfsec:ignore:AWS051
   tags                                = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -208,12 +208,6 @@ variable "security_group_ids" {
   description = "List of security group IDs allowed to connect to Aurora"
 }
 
-variable "skip_final_snapshot" {
-  type        = bool
-  default     = false
-  description = "Determines whether a final snapshot is created before deleting the cluster"
-}
-
 variable "snapshot_identifier" {
   type        = string
   default     = null


### PR DESCRIPTION
This PR removed the `skip_final_snapshot` variable and calculates it based on the `final_snapshot_identifier`.

**Reasoning:**
I removed the `final_shapshot_identifier` and assumed that was enough the make RDS recreate (on purpose, also disabled the deletion protection). So hit the error:

`Error: RDS Cluster final_snapshot_identifier is required when skip_final_snapshot is false`

Since the 2 variables are dependent on each other, made this PR to calculate the `skip_final_snapshot` variable. Want a final snapshot: Specify `final_snapshot_identifier` and done.