### PR TITLE
enhancement: change count for cluster instances to for each

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -161,10 +161,11 @@ variable "instance_class" {
 variable "instance_config" {
   description = "Map of instance specific settings that override values set elsewhere in the module, map keys should match instance number"
   type = map(object({
+    identifier     = optional(string, null)
     instance_class = optional(string, null)
     promotion_tier = optional(number, null)
   }))
-  default = null
+  default = {}
 }
 
 variable "instance_count" {


### PR DESCRIPTION
- simplefy code by changing count for the cluster instances to for each
- replace all serverless checks with a **local.is_serverless** bool
- adding the option to overide the instance name using identifier property in the var.instances map
`instances = { 1 = {identifier = "myinstance-non-prod-0"} }`