### PR TITLE
bug: support the creation of multiple RDS cluster endpoints in a single account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,13 +70,13 @@ resource "aws_rds_cluster" "default" {
 ################################################################################
 
 resource "aws_rds_cluster_endpoint" "default" {
-  for_each = { for identifier, settings in var.endpoints : identifier => settings if var.engine_mode != "serverless" }
+  for_each = { for name, settings in var.endpoints : name => settings if var.engine_mode != "serverless" }
 
-  cluster_endpoint_identifier = lower(each.key)
+  cluster_endpoint_identifier = lower("${aws_rds_cluster.default.id}-${each.key}")
   cluster_identifier          = aws_rds_cluster.default.id
   custom_endpoint_type        = each.value.type
-  excluded_members            = length(var.endpoints.reader.excluded_members) == 0 ? null : [for member in each.value.excluded_members : "${var.name}-${member}"]
-  static_members              = length(var.endpoints.reader.static_members) == 0 ? null : [for member in each.value.static_members : "${var.name}-${member}"]
+  excluded_members            = length(each.value.excluded_members) == 0 ? null : [for member in each.value.excluded_members : "${var.name}-${member}"]
+  static_members              = length(each.value.static_members) == 0 ? null : [for member in each.value.static_members : "${var.name}-${member}"]
   tags                        = var.tags
 
   depends_on = [


### PR DESCRIPTION
- Currently the key of the map is used to name the RDS Cluster endpoint, this name has to be unique for the whole AWS account. 
- We currently expect this name to be "reader", and do not allow other input.
- When creating multiple clusters in a single account there is currently no way to change this value to something else.

- This PR adds support for creating multiple endpoints and ensures a unique name by concatenating the cluster id with the endpoint name. 