### PR TITLE
bug(entrypoint): Depend on cluster instances to exist

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,8 @@ resource "aws_rds_cluster_endpoint" "default" {
   tags                        = var.tags
 
   depends_on = [
-    aws_rds_cluster.default
+    aws_rds_cluster_instance.first,
+    aws_rds_cluster_instance.rest,
   ]
 }
 


### PR DESCRIPTION
The `aws_rds_cluster_endpoint` resource fails when creating a new
cluster as the instances do not yet exist.

This Updates the dependency to wait for `aws_rds_cluster_instance.first`
and `aws_rds_cluster_instance.rest` to complete before attempting to
create a cluster endpoint.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
