### PR TITLE
bug: solve dependency isues with modifying parameter groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -197,6 +197,10 @@ resource "aws_rds_cluster_parameter_group" "default" {
       value        = parameter.value.value
     }
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 ################################################################################
@@ -219,6 +223,10 @@ resource "aws_db_parameter_group" "default" {
       name         = parameter.value.name
       value        = parameter.value.value
     }
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
The [create_before_destroy](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) lifecycle configuration is necessary for modifications that force re-creation of an existing, in-use parameter group. This includes common situations like changing the group name or bumping the family version during a major version upgrade. This configuration will prevent destruction of the deposed group while still in use by the database during upgrade.