### PR TITLE
feat: Add PostgreSQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This can be changed by updating `var.instance_count`. By default all instances u
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_engine"></a> [engine](#input\_engine) | The engine type of the Aurora cluster | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name for the Aurora Cluster | `string` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs to deploy Aurora in | `list(string)` | n/a | yes |
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster. (Required for Multi-AZ DB cluster) | `number` | `null` | no |
@@ -58,21 +59,21 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any cluster modifications are applied immediately | `bool` | `true` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |
 | <a name="input_auto_pause"></a> [auto\_pause](#input\_auto\_pause) | Whether to enable automatic pause | `bool` | `true` | no |
-| <a name="input_backtrack_window"></a> [backtrack\_window](#input\_backtrack\_window) | The target backtrack window, in seconds. Only available for `aurora` and `aurora-mysql` engines. To disable backtracking, set this value to 0. Must be between 0 and 259200 (72 hours) | `number` | `null` | no |
-| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | The days to retain backups for | `number` | `7` | no |
+| <a name="input_backtrack_window"></a> [backtrack\_window](#input\_backtrack\_window) | The target backtrack window, in seconds. Only available for `mysql` engines. Must be between 0 (disabled) and 259200 (72 hours) | `number` | `0` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Number of days to retain backups for | `number` | `7` | no |
 | <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Identifier of the CA certificate for the DB instance | `string` | `"rds-ca-rsa2048-g1"` | no |
-| <a name="input_cluster_family"></a> [cluster\_family](#input\_cluster\_family) | The family of the DB cluster parameter group | `string` | `"aurora-mysql8.0"` | no |
+| <a name="input_cluster_family"></a> [cluster\_family](#input\_cluster\_family) | The family of the DB cluster parameter group | `string` | `null` | no |
 | <a name="input_cluster_parameters"></a> [cluster\_parameters](#input\_cluster\_parameters) | A list of cluster DB parameters to apply | <pre>list(object({<br>    apply_method = optional(string, "immediate")<br>    name         = string<br>    value        = string<br>  }))</pre> | <pre>[<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "character_set_server",<br>    "value": "utf8"<br>  },<br>  {<br>    "apply_method": "pending-reboot",<br>    "name": "character_set_client",<br>    "value": "utf8"<br>  },<br>  {<br>    "apply_method": "immediate",<br>    "name": "require_secure_transport",<br>    "value": "ON"<br>  }<br>]</pre> | no |
 | <a name="input_database"></a> [database](#input\_database) | The name of the first database to be created when the cluster is created | `string` | `null` | no |
 | <a name="input_database_parameters"></a> [database\_parameters](#input\_database\_parameters) | A list of instance DB parameters to apply | <pre>list(object({<br>    apply_method = optional(string, "immediate")<br>    name         = string<br>    value        = string<br>  }))</pre> | `null` | no |
 | <a name="input_db_cluster_instance_class"></a> [db\_cluster\_instance\_class](#input\_db\_cluster\_instance\_class) | The compute and memory capacity of each DB instance in the Multi-AZ DB cluster. Only set this variable if you are deploying a Multi-AZ DB cluster. (Required for Multi-AZ DB cluster) | `string` | `null` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | A boolean indicating if the DB instance should have deletion protection enable | `bool` | `true` | no |
+| <a name="input_enable_cloudwatch_logs_exports"></a> [enable\_cloudwatch\_logs\_exports](#input\_enable\_cloudwatch\_logs\_exports) | Set to false to disable logging to cloudwatch | `bool` | `true` | no |
 | <a name="input_enable_http_endpoint"></a> [enable\_http\_endpoint](#input\_enable\_http\_endpoint) | Enable Aurora Serverless HTTP endpoint (Data API) | `bool` | `false` | no |
-| <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to export to cloudwatch | `list(string)` | <pre>[<br>  "audit"<br>]</pre> | no |
+| <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to export to cloudwatch, by default all supported types are exported | `list(string)` | `null` | no |
 | <a name="input_endpoints"></a> [endpoints](#input\_endpoints) | A map of additional cluster endpoints to be created | <pre>map(object({<br>    excluded_members = optional(list(string), [])<br>    static_members   = optional(list(string), [])<br>    type             = string<br>  }))</pre> | `{}` | no |
-| <a name="input_engine"></a> [engine](#input\_engine) | The engine type of the Aurora cluster | `string` | `"aurora-mysql"` | no |
 | <a name="input_engine_mode"></a> [engine\_mode](#input\_engine\_mode) | The engine mode of the Aurora cluster | `string` | `"provisioned"` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version of the Aurora cluster | `string` | `"8.0.mysql_aurora.3.02.2"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version of the Aurora cluster | `string` | `null` | no |
 | <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | Identifier of the final snapshot to create before deleting the cluster | `string` | `null` | no |
 | <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | Specify if mapping AWS IAM accounts to database accounts is enabled. | `bool` | `true` | no |
 | <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | A list of IAM Role ARNs to associate with the cluster | `list(string)` | `null` | no |
@@ -84,13 +85,13 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | <a name="input_manage_master_user"></a> [manage\_master\_user](#input\_manage\_master\_user) | Set to false to provide a custom password using `master_password` | `bool` | `true` | no |
 | <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Password for the master DB user, must set `manage_master_user` to false if specifying a custom password | `string` | `null` | no |
 | <a name="input_master_user_secret_kms_key_id"></a> [master\_user\_secret\_kms\_key\_id](#input\_master\_user\_secret\_kms\_key\_id) | ID of KMS key to encrypt the master user Secrets Manager secret | `string` | `null` | no |
-| <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Username for the master DB user | `string` | `"root"` | no |
+| <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Username for the master DB user | `string` | `null` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | The maximum capacity of the serverless cluster | `string` | `8` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | The minimum capacity of the serverless cluster | `string` | `1` | no |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval (seconds) for collecting enhanced monitoring metrics | `string` | `null` | no |
 | <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | The name for the DB / RDS cluster parameter groups | `string` | `null` | no |
 | <a name="input_performance_insights"></a> [performance\_insights](#input\_performance\_insights) | Specifies whether Performance Insights is enabled or not | `bool` | `true` | no |
-| <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time in days to retain Performance Insights data. Valida values are 7, 731 (2 years) or a multiple of 31. When specifying performance\_insights\_retention\_period, performance\_insights needs to be set to true | `number` | `7` | no |
+| <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time in days to retain Performance Insights data, must be `7`, `731` (2 years) or a multiple of `31` | `number` | `7` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the role | `string` | `null` | no |
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | The daily time range during which automated backups are created, in UTC e.g. 04:00-09:00 | `string` | `null` | no |
 | <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range during which system maintenance can occur, in UTC e.g. wed:04:00-wed:04:30 | `string` | `null` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -30,6 +30,7 @@ module "aurora" {
   source = "../.."
 
   name                          = "example"
+  engine                        = "mysql"
   instance_class                = "db.r6g.large"
   kms_key_id                    = module.kms.arn
   master_user_secret_kms_key_id = module.kms.arn

--- a/examples/custom-password/main.tf
+++ b/examples/custom-password/main.tf
@@ -35,6 +35,7 @@ module "aurora" {
   source = "../.."
 
   name                          = "example"
+  engine                        = "mysql"
   instance_class                = "db.r6g.large"
   kms_key_id                    = module.kms.arn
   manage_master_user            = false

--- a/examples/endpoints-and-instance-config/main.tf
+++ b/examples/endpoints-and-instance-config/main.tf
@@ -30,6 +30,7 @@ module "aurora" {
   source = "../.."
 
   name                          = "example"
+  engine                        = "mysql"
   instance_class                = "db.r6g.large"
   instance_count                = 3
   kms_key_id                    = module.kms.arn

--- a/examples/multi-az/main.tf
+++ b/examples/multi-az/main.tf
@@ -34,6 +34,7 @@ module "aurora" {
   name                          = "example"
   allocated_storage             = 100
   db_cluster_instance_class     = "db.r6gd.xlarge"
+  engine                        = "mysql"
   instance_count                = 3
   iops                          = 1000
   kms_key_id                    = module.kms.arn

--- a/examples/security-group-ingress-rules/main.tf
+++ b/examples/security-group-ingress-rules/main.tf
@@ -30,6 +30,7 @@ module "aurora" {
   source = "../.."
 
   name                          = "example"
+  engine                        = "mysql"
   instance_class                = "db.r6g.large"
   kms_key_id                    = module.kms.arn
   master_user_secret_kms_key_id = module.kms.arn


### PR DESCRIPTION
Using PostgreSQL with this module was always possible but required overriding defaults as this module was geared towards MySQL as a default.

Noticeable changes:

- `var.engine` is now required and only allows `mysql` or `postgresql` as these are the only two Aurora types
- Other variables that defaulted to MySQL values have been removed and replaced with a default per engine and allow overriding using the user facing variable (e.g. `master_username` defaults to an engine specific value whilst still letting the user set their own if they so desire)
- Added more variable validation

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
