### PR TITLE
bug: Fix resetting tags on every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.62.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 
@@ -100,7 +100,7 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Database snapshot identifier to create the database from | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted | `bool` | `true` | no |
 | <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Specifies the storage type to be associated with the DB cluster. (Required for Multi-AZ DB cluster) | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket | `map(string)` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket | `map(string)` | `null` | no |
 | <a name="input_timeout_action"></a> [timeout\_action](#input\_timeout\_action) | The action to take when the timeout is reached | `string` | `"RollbackCapacityChange"` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -360,7 +360,7 @@ variable "subnet_ids" {
 
 variable "tags" {
   type        = map(string)
-  default     = {}
+  default     = null
   description = "A mapping of tags to assign to the bucket"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.62.0"
+      version = ">= 5.0"
     }
   }
   required_version = ">= 1.3"


### PR DESCRIPTION
Each time Terraform ran it was attempting to set `tags = {}` on some resources. Testing this with AWS provider v5, with `tags = null` we no longer see this showing as a change in our plans.

<img width="897" alt="image" src="https://github.com/schubergphilis/terraform-aws-mcaf-aurora/assets/3757382/b4e5f6b1-0ca0-444f-8f64-aaa433514bef">


Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
