### PR TITLE
feature: Implement seconds_until_auto_pause to Serverless V2 and make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.62.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81.0 |
 
 ## Modules
 
@@ -96,6 +96,7 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | The daily time range during which automated backups are created, in UTC e.g. 04:00-09:00 | `string` | `null` | no |
 | <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range during which system maintenance can occur, in UTC e.g. wed:04:00-wed:04:30 | `string` | `null` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Control if instances in cluster are publicly accessible | `string` | `false` | no |
+| <a name="input_seconds_until_auto_pause"></a> [seconds\_until\_auto\_pause](#input\_seconds\_until\_auto\_pause) | The time, in seconds, before an Aurora Serverless DB cluster is paused | `number` | `1800` | no |
 | <a name="input_security_group_ingress_rules"></a> [security\_group\_ingress\_rules](#input\_security\_group\_ingress\_rules) | Security Group ingress rules | <pre>list(object({<br>    cidr_ipv4                    = optional(string)<br>    cidr_ipv6                    = optional(string)<br>    description                  = string<br>    prefix_list_id               = optional(string)<br>    referenced_security_group_id = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Database snapshot identifier to create the database from | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_rds_cluster" "default" {
       auto_pause               = var.auto_pause
       max_capacity             = var.max_capacity
       min_capacity             = var.min_capacity
-      seconds_until_auto_pause = 1800
+      seconds_until_auto_pause = var.seconds_until_auto_pause
       timeout_action           = var.timeout_action
     }
   }
@@ -88,8 +88,9 @@ resource "aws_rds_cluster" "default" {
     for_each = var.engine_mode == "serverlessv2" ? { create : null } : {}
 
     content {
-      max_capacity = var.max_capacity
-      min_capacity = var.min_capacity
+      max_capacity             = var.max_capacity
+      min_capacity             = var.min_capacity
+      seconds_until_auto_pause = var.seconds_until_auto_pause
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -330,6 +330,17 @@ variable "security_group_ingress_rules" {
   }
 }
 
+variable "seconds_until_auto_pause" {
+  type        = number
+  default     = 1800
+  description = "The time, in seconds, before an Aurora Serverless DB cluster is paused"
+
+  validation {
+    condition     = provider::assert::between(300, 86400, var.seconds_until_auto_pause)
+    error_message = "seconds_until_auto_pause must be between 300 (5 minutes) and 86400 (1 day)"
+  }
+}
+
 variable "snapshot_identifier" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -336,7 +336,7 @@ variable "seconds_until_auto_pause" {
   description = "The time, in seconds, before an Aurora Serverless DB cluster is paused"
 
   validation {
-    condition     = provider::assert::between(300, 86400, var.seconds_until_auto_pause)
+    condition     = var.seconds_until_auto_pause >= 300 && var.seconds_until_auto_pause <= 86400
     error_message = "seconds_until_auto_pause must be between 300 (5 minutes) and 86400 (1 day)"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,13 @@
 terraform {
   required_providers {
+    assert = {
+      source  = "hashicorp/assert"
+      version = ">= 0.14.0"
+    }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.62.0"
+      version = ">= 5.81.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.8"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,13 +1,9 @@
 terraform {
   required_providers {
-    assert = {
-      source  = "hashicorp/assert"
-      version = ">= 0.14.0"
-    }
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.81.0"
     }
   }
-  required_version = ">= 1.8"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
This PR implements the "Seconds Until Autopauze" setting for Serverless V2.

Serverless V2 now supports scaling back to 0. With this PR it's also supported in this module. Also made it configurable, it was hardcoded on 5 minutes.

**Documentation and Links:**

* https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-aurora-serverless-v2-scaling-zero-capacity/
* https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.81.0
* https://github.com/hashicorp/terraform-provider-aws/pull/40453
* https://registry.terraform.io/providers/hashicorp/assert/latest/docs/functions/between