### PR TITLE
fix: Correct variable types

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -244,13 +244,13 @@ variable "master_username" {
 }
 
 variable "max_capacity" {
-  type        = string
+  type        = number
   default     = 8
   description = "The maximum capacity of the serverless cluster"
 }
 
 variable "min_capacity" {
-  type        = string
+  type        = number
   default     = 1
   description = "The minimum capacity of the serverless cluster"
 }


### PR DESCRIPTION
This PR corrects the variable types.

Been using this module for years and never noticed the `min_capacity` and `max_capacity` are strings. We've always also configured them as numbers. Notices this when I was wondering why the scaling back to 0 doesn't work:

```
      seconds_until_auto_pause = var.min_capacity == 0 ? var.seconds_until_auto_pause : null
```

Instead of changing the check to string, I've decided to change the type. Since this basically fits under the recent minor version update as far as I'm concerned. 