### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -100,6 +100,7 @@ This can be changed by updating `var.instance_count`. By default all instances u
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | The daily time range during which automated backups are created, in UTC e.g. 04:00-09:00 | `string` | `null` | no |
 | <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range during which system maintenance can occur, in UTC e.g. wed:04:00-wed:04:30 | `string` | `null` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Control if instances in cluster are publicly accessible | `string` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_seconds_until_auto_pause"></a> [seconds\_until\_auto\_pause](#input\_seconds\_until\_auto\_pause) | The time, in seconds, before an Aurora Serverless DB cluster is paused | `number` | `1800` | no |
 | <a name="input_security_group_ingress_rules"></a> [security\_group\_ingress\_rules](#input\_security\_group\_ingress\_rules) | Security Group ingress rules | <pre>list(object({<br/>    cidr_ipv4                    = optional(string)<br/>    cidr_ipv6                    = optional(string)<br/>    description                  = string<br/>    prefix_list_id               = optional(string)<br/>    referenced_security_group_id = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Database snapshot identifier to create the database from | `string` | `null` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@
 
 This document captures breaking changes.
 
+## Upgrading to v1.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0 to support the `region` parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+
+
 ## Upgrading to v4.0.0
 
 ### Variables

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.8"

--- a/examples/custom-password/terraform.tf
+++ b/examples/custom-password/terraform.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.4.0"
+      version = "~> 3.8"
     }
   }
   required_version = ">= 1.8"

--- a/examples/endpoints-and-instance-config/terraform.tf
+++ b/examples/endpoints-and-instance-config/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.8"

--- a/examples/global-database/terraform.tf
+++ b/examples/global-database/terraform.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.4.0"
+      version = "~> 3.8"
     }
   }
   required_version = ">= 1.8"

--- a/examples/multi-az/terraform.tf
+++ b/examples/multi-az/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.8"

--- a/examples/security-group-ingress-rules/terraform.tf
+++ b/examples/security-group-ingress-rules/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.8"

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,8 @@ locals {
 }
 
 data "aws_subnet" "selected" {
-  id = var.subnet_ids[0]
+  region = var.region
+  id     = var.subnet_ids[0]
 }
 
 ################################################################################
@@ -41,12 +42,14 @@ data "aws_subnet" "selected" {
 ################################################################################
 
 data "aws_kms_alias" "rds" {
-  name = "alias/aws/rds"
+  region = var.region
+  name   = "alias/aws/rds"
 }
 
 resource "aws_rds_global_cluster" "default" {
   count = var.global_database_primary ? 1 : 0
 
+  region                    = var.region
   global_cluster_identifier = "${var.name}-global"
   engine                    = "aurora-${var.engine}"
   engine_version            = var.engine_version
@@ -61,6 +64,7 @@ resource "aws_rds_global_cluster" "default" {
 
 resource "aws_rds_cluster" "default" {
   #checkov:skip=CKV2_AWS_8: Ensuring that RDS clusters have an AWS Backup backup plan is not the responsibility of this module
+  region                              = var.region
   allocated_storage                   = var.allocated_storage
   allow_major_version_upgrade         = var.allow_major_version_upgrade
   apply_immediately                   = var.apply_immediately
@@ -132,6 +136,7 @@ resource "aws_rds_cluster" "default" {
 resource "aws_rds_cluster_endpoint" "default" {
   for_each = { for name, settings in var.endpoints : name => settings if var.engine_mode != "serverless" }
 
+  region                      = var.region
   cluster_endpoint_identifier = lower("${aws_rds_cluster.default.id}-${each.key}")
   cluster_identifier          = aws_rds_cluster.default.id
   custom_endpoint_type        = each.value.type
@@ -156,6 +161,7 @@ therefore a main cluster instance resource is created and additional cluster ins
 resource "aws_rds_cluster_instance" "first" {
   count = var.engine_mode == "serverless" ? 0 : 1
 
+  region                                = var.region
   apply_immediately                     = var.apply_immediately
   auto_minor_version_upgrade            = var.auto_minor_version_upgrade
   ca_cert_identifier                    = var.ca_cert_identifier
@@ -180,6 +186,7 @@ resource "aws_rds_cluster_instance" "first" {
 resource "aws_rds_cluster_instance" "rest" {
   count = var.engine_mode == "serverless" ? 0 : var.instance_count - 1
 
+  region                                = var.region
   apply_immediately                     = var.apply_immediately
   auto_minor_version_upgrade            = var.auto_minor_version_upgrade
   ca_cert_identifier                    = var.ca_cert_identifier
@@ -210,6 +217,7 @@ resource "aws_rds_cluster_instance" "rest" {
 ################################################################################
 
 resource "aws_db_subnet_group" "default" {
+  region     = var.region
   name       = var.name
   subnet_ids = var.subnet_ids
   tags       = var.tags
@@ -241,6 +249,7 @@ module "rds_enhanced_monitoring_role" {
 resource "aws_rds_cluster_parameter_group" "default" {
   count = var.cluster_parameters != null ? 1 : 0
 
+  region      = var.region
   name        = coalesce(var.parameter_group_name, var.name)
   description = "RDS default cluster parameter group"
   family      = local.cluster_family
@@ -268,6 +277,7 @@ resource "aws_rds_cluster_parameter_group" "default" {
 resource "aws_db_parameter_group" "default" {
   count = var.database_parameters != null ? 1 : 0
 
+  region      = var.region
   name        = coalesce(var.parameter_group_name, "${var.name}-aurora")
   description = "RDS default database parameter group"
   family      = local.cluster_family
@@ -293,6 +303,7 @@ resource "aws_db_parameter_group" "default" {
 ################################################################################
 
 resource "aws_security_group" "default" {
+  region      = var.region
   name        = "${var.name}-aurora"
   description = "Access to Aurora"
   vpc_id      = data.aws_subnet.selected.vpc_id
@@ -302,6 +313,7 @@ resource "aws_security_group" "default" {
 resource "aws_vpc_security_group_ingress_rule" "default" {
   for_each = length(var.security_group_ingress_rules) != 0 ? { for v in var.security_group_ingress_rules : v.description => v } : {}
 
+  region                       = var.region
   cidr_ipv4                    = each.value.cidr_ipv4
   cidr_ipv6                    = each.value.cidr_ipv6
   description                  = each.value.description

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.8"

--- a/variables.tf
+++ b/variables.tf
@@ -353,6 +353,12 @@ variable "publicly_accessible" {
   description = "Control if instances in cluster are publicly accessible"
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "seconds_until_auto_pause" {
   type        = number
   default     = 1800


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the MCAF User Terraform module to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for all related resources, which improves multi-region compatibility and control. The AWS provider version is updated to the latest major version.

**Region configuration improvements:** 

* Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for resources. If omitted, the default provider region is used.


## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.
